### PR TITLE
Correct README quick start formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,22 +37,22 @@ unpack it to a directory.
 
 	```
 	$ ./litepub build
-  Generating: index.html
-  Generating: tags/reference.html
-  Generating: tags/tutorial.html
-  Generating: tags/advanced.html
-  Generating: tags/docs.html
-  Generating: tags/basics.html
-  Generating: overview.html
-  Generating: quick-start.html
-  Generating: installation.html
-  Generating: creating-a-blog.html
-  Generating: creating-posts.html
-  Generating: generating-html-files-for-a-blog-aka-building-a-blog.html
-  Generating: serving-a-blog.html
-  Generating: templates.html
-  Generating: getting-help.html
-	```
+    Generating: index.html
+    Generating: tags/reference.html
+    Generating: tags/tutorial.html
+    Generating: tags/advanced.html
+    Generating: tags/docs.html
+    Generating: tags/basics.html
+    Generating: overview.html
+    Generating: quick-start.html
+    Generating: installation.html
+    Generating: creating-a-blog.html
+    Generating: creating-posts.html
+    Generating: generating-html-files-for-a-blog-aka-building-a-blog.html
+    Generating: serving-a-blog.html
+    Generating: templates.html
+    Generating: getting-help.html
+    ```
 
 5. Run the built-in server:
 


### PR DESCRIPTION
The formatting was off for the output of `litepub build` in the quick start section.  This corrects it.